### PR TITLE
console.warn and and reject promises for non-whitelisted messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ringtail-extension-sdk",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Provides APIs for UI Extensions to communicate with Ringtail",
   "main": "Ringtail.js",
   "scripts": {

--- a/tests/whitelist.test.js
+++ b/tests/whitelist.test.js
@@ -29,8 +29,9 @@ describe('initialize', () => {
         Test.postMessageMock.mockClear();
     });
 
-    test('should silently reject messages from non-whitelisted domains', async () => {
+    test('should reject messages from non-whitelisted domains', async () => {
         const activeDocHandler = jest.fn().mockName('handleActiveDoc');
+        console.warn = jest.fn().mockName('console.warn');
         Ringtail.on('ActiveDocument', activeDocHandler);
 
         Test.sendMessage({
@@ -39,5 +40,6 @@ describe('initialize', () => {
         }, 'http://we-be-pirates.com');
 
         expect(activeDocHandler).toHaveBeenCalledTimes(0);
+        expect(console.warn).toHaveBeenCalledTimes(1);
     });
 });


### PR DESCRIPTION
These changes are intended to improve the developer experience by helping isolate errors with the whitelist.