### PR TITLE
Ignore internal messages sent from the same domain hosting the extension

### DIFF
--- a/Ringtail.js
+++ b/Ringtail.js
@@ -64,6 +64,10 @@
         var message = event.data;
         var deferred = getDeferred(message.requestId);
 
+        if (window.location.origin === event.origin) {
+            // Ignore messages sent internally - they should NOT cause warnings
+            return;
+        }
         if (allowedDomains.length > 0 && allowedDomains.indexOf(event.origin) < 0) {
             var msg = 'Rejected message from non-whitelisted domain: ' + event.origin;
             console.warn('WARNING:', msg);

--- a/package.json
+++ b/package.json
@@ -23,5 +23,9 @@
     "eslint": "^4.18.2",
     "eslint-plugin-jest": "^21.13.0",
     "jest": "^22.4.2"
+  },
+  "jest": {
+    "verbose": true,
+    "testURL": "http://fake.domain/"
   }
 }

--- a/tests/whitelist.test.js
+++ b/tests/whitelist.test.js
@@ -42,4 +42,18 @@ describe('initialize', () => {
         expect(activeDocHandler).toHaveBeenCalledTimes(0);
         expect(console.warn).toHaveBeenCalledTimes(1);
     });
+
+    test('should ignore internal messages from its own domain', async () => {
+        const activeDocHandler = jest.fn().mockName('handleActiveDoc');
+        console.warn = jest.fn().mockName('console.warn');
+        Ringtail.on('ActiveDocument', activeDocHandler);
+
+        Test.sendMessage({
+            name: 'InteralMessageName',
+            data: {}
+        }, 'http://fake.domain'); // From package.json
+
+        expect(activeDocHandler).toHaveBeenCalledTimes(0);
+        expect(console.warn).toHaveBeenCalledTimes(0);
+    });
 });


### PR DESCRIPTION
Messages sent internally inside an extension application caused console warnings unnecessarily. This change simply disregards such messages, assuming they'll be handled by the extension.